### PR TITLE
housekeeping

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -20,13 +20,19 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: ^1
+          go-version-file: go.mod
+          check-latest: true
 
       - name: Vet Go code
         run: go vet ./...
 
       - name: Test Go code
         run: go test -v -race ./...
+
+      - name: Test Go without cgo
+        env:
+          CGO_ENABLED: 0
+        run: go test -v ./...
 
       - name: Verify repo is unchanged
         run: git diff --exit-code HEAD

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # EPP for Go
 
-[![build status](https://img.shields.io/github/workflow/status/domainr/epp2/Go.svg)](https://github.com/domainr/epp2/actions)
+[![build status](https://img.shields.io/github/actions/workflow/status/domainr/epp2/go.yaml?branch=main)](https://github.com/domainr/epp2/actions)
 [![pkg.go.dev](https://img.shields.io/badge/docs-pkg.go.dev-blue.svg)](https://pkg.go.dev/github.com/domainr/epp2)
+
 
 Extensible Provisioning Protocol (EPP) for
 [Go](https://go.dev/).


### PR DESCRIPTION
- README: fix badges
- .github/workflows/go: run tests without Cgo, use go.mod for Go version
