### PR TITLE
fix: test race condition

### DIFF
--- a/protocol/dataunit/client_server_test.go
+++ b/protocol/dataunit/client_server_test.go
@@ -220,7 +220,7 @@ func echoServer(ctx context.Context, s *Server, echoServerErr chan<- error) {
 }
 
 func randDuration(max time.Duration) time.Duration {
-	return time.Duration(rand.Int64N(int64(max)))
+	return time.Duration(rand.N(max))
 }
 
 var (

--- a/protocol/dataunit/client_server_test.go
+++ b/protocol/dataunit/client_server_test.go
@@ -40,7 +40,7 @@ func TestEchoClientAndServer(t *testing.T) {
 	s := &Server{Conn: serverConn}
 
 	var mu sync.Mutex
-	go echoServer(t, ctx, s, &mu)
+	go echoServer(ctx, t, s, &mu)
 
 	sem := make(chan struct{}, 2)
 	var wg sync.WaitGroup
@@ -87,7 +87,7 @@ func TestClientContextDeadline(t *testing.T) {
 	c := &Client{Conn: clientConn}
 	s := &Server{Conn: serverConn}
 	var mu sync.Mutex
-	go echoServer(t, ctx, s, &mu)
+	go echoServer(ctx, t, s, &mu)
 
 	wantErr := errors.New("test deadline exceeded")
 	ctx, cancel2 := context.WithDeadlineCause(ctx, time.Now(), wantErr)
@@ -110,7 +110,7 @@ func TestClientContextCancelled(t *testing.T) {
 	c := &Client{Conn: clientConn}
 	s := &Server{Conn: serverConn}
 	var mu sync.Mutex
-	go echoServer(t, ctx, s, &mu)
+	go echoServer(ctx, t, s, &mu)
 
 	_, err := c.ExchangeDataUnit(ctx, []byte("hello"))
 	if err != wantErr {
@@ -135,7 +135,7 @@ func TestServerContextCancelled(t *testing.T) {
 	cancel(wantErr)
 
 	var mu sync.Mutex
-	err := echoServer(t, serverCtx, s, &mu)
+	err := echoServer(serverCtx, t, s, &mu)
 	if err != wantErr {
 		mu.Lock()
 		t.Errorf("echoServer(): err == %v, expected %v", err, wantErr)
@@ -170,7 +170,7 @@ func TestMultipleResponseError(t *testing.T) {
 
 // echoServer implements a rudimentary EPP data unit server that echoes
 // back each received request.
-func echoServer(t *testing.T, ctx context.Context, s *Server, mu *sync.Mutex) error {
+func echoServer(ctx context.Context, t *testing.T, s *Server, mu *sync.Mutex) error {
 	ctx, cancel := context.WithCancelCause(ctx)
 	defer cancel(errTestDone)
 

--- a/protocol/dataunit/client_server_test.go
+++ b/protocol/dataunit/client_server_test.go
@@ -90,7 +90,7 @@ func TestClientContextDeadline(t *testing.T) {
 	defer cancel2()
 
 	_, err := c.ExchangeDataUnit(ctx, []byte("hello"))
-	if !errors.Is(err, wantErr) {
+	if err != wantErr {
 		echoServerErr <- fmt.Errorf("ExchangeDataUnit(): err == %w, expected %w", err, wantErr)
 	}
 	close(echoServerErr)
@@ -112,7 +112,7 @@ func TestClientContextCancelled(t *testing.T) {
 	go echoServer(ctx, s, echoServerErr)
 
 	_, err := c.ExchangeDataUnit(ctx, []byte("hello"))
-	if !errors.Is(err, wantErr) {
+	if err != wantErr {
 		echoServerErr <- fmt.Errorf("ExchangeDataUnit(): err == %w, expected %w", err, wantErr)
 	}
 	close(echoServerErr)
@@ -142,7 +142,7 @@ func TestServerContextCancelled(t *testing.T) {
 	go echoServer(serverCtx, s, echoServerErr)
 
 	for err := range echoServerErr {
-		if !errors.Is(err, wantErr) {
+		if err != wantErr {
 			t.Errorf("unexpected error: %s", err)
 		}
 	}
@@ -170,7 +170,7 @@ func TestMultipleResponseError(t *testing.T) {
 	}
 	err = r.RespondDataUnit(ctx, req)
 	wantErr := MultipleResponseError{Index: 0, Count: 2}
-	if !errors.Is(err, wantErr) {
+	if err != wantErr {
 		t.Errorf("RespondDataUnit(): err == %v, expected %v", err, wantErr)
 	}
 }
@@ -185,7 +185,7 @@ func echoServer(ctx context.Context, s *Server, echoServerErr chan<- error) {
 	for {
 		err := context.Cause(ctx)
 		if err != nil {
-			if errors.Is(err, errTestDone) || errors.Is(err, errCtxCancelled) {
+			if err == errTestDone || err == errCtxCancelled {
 				return
 			}
 			echoServerErr <- err
@@ -201,7 +201,7 @@ func echoServer(ctx context.Context, s *Server, echoServerErr chan<- error) {
 
 			data, r, err := s.ServeDataUnit(reqCtx)
 			if err != nil {
-				if errors.Is(err, errTestDone) {
+				if err == errTestDone {
 					return
 				}
 				echoServerErr <- fmt.Errorf("echoServer: ServeDataUnit(): err == %w", err)
@@ -210,7 +210,7 @@ func echoServer(ctx context.Context, s *Server, echoServerErr chan<- error) {
 			time.Sleep(randDuration(10 * time.Millisecond))
 			err = r.RespondDataUnit(reqCtx, data)
 			if err != nil {
-				if errors.Is(err, errTestDone) {
+				if err == errTestDone {
 					return
 				}
 				echoServerErr <- fmt.Errorf("echoServer: RespondDataUnit(): err == %w", err)

--- a/protocol/dataunit/client_server_test.go
+++ b/protocol/dataunit/client_server_test.go
@@ -53,7 +53,7 @@ func TestEchoClientAndServer(t *testing.T) {
 				t.Errorf("ExchangeDataUnit(): got %s, expected %s", string(res), string(data))
 				mu.Unlock()
 			}
-			t.Logf("data received from server connection: %s\n", res)
+			// t.Logf("data received from server connection: %s\n", res)
 			<-sem
 		}()
 	}
@@ -184,7 +184,7 @@ func echoServer(t *testing.T, ctx context.Context, s *Server, mu *sync.Mutex) er
 				t.Errorf("echoServer: ServeDataUnit(): err == %v", err)
 				mu.Unlock()
 			}
-			t.Logf("data received from client connection: %s\n", data)
+			// t.Logf("data received from client connection: %s\n", data)
 			time.Sleep(randDuration(10 * time.Millisecond))
 			err = r.RespondDataUnit(reqCtx, data)
 			if err != nil {

--- a/protocol/dataunit/client_server_test.go
+++ b/protocol/dataunit/client_server_test.go
@@ -12,6 +12,25 @@ import (
 	"time"
 )
 
+// TestEchoClientAndServer validates the EPP server is able to read the data
+// provided in the client request and to respond back correctly.
+//
+// It does this by passing an instance of a `Server` to `echoServer()`, which
+// runs in a goroutine. The echo server runs forever or until the passed in
+// context is cancelled. Inside the echo server it checks for
+// `testing.T.Failed()` and stops if there is a test failure. Otherwise, it
+// handles 10 requests at a time, spinning up each request in a new goroutine.
+// Each goroutine handles a response to the client request. Each request is
+// sending a unique 'data unit' to be processed and the response is sent back to
+// the `serverConn` which .
+//
+// We use a `net.Pipe()` to simulate the client/server request/response flows.
+// i.e. a write to `clientConn` is readable via `serverConn` (and vice-versa).
+//
+// So c.ExchangeDataUnit() writes data to the `clientConn` which causes a copy
+// of the data to be written into `serverConn` for it to read. Then writing to
+// `serverConn` causes a copy of that data to be written into `clientConn` for
+// it to read. Simulating a bidirectional network connection.
 func TestEchoClientAndServer(t *testing.T) {
 	ctx, cancel := context.WithCancelCause(context.Background())
 	defer cancel(errTestDone)

--- a/protocol/dataunit/client_server_test.go
+++ b/protocol/dataunit/client_server_test.go
@@ -183,6 +183,7 @@ func echoServer(t *testing.T, ctx context.Context, s *Server, mu *sync.Mutex) er
 				t.Errorf("echoServer: ServeDataUnit(): err == %v", err)
 				mu.Unlock()
 			}
+			t.Logf("data received from client connection: %s\n", data)
 			time.Sleep(randDuration(10 * time.Millisecond))
 			err = r.RespondDataUnit(reqCtx, data)
 			if err != nil {

--- a/protocol/dataunit/client_server_test.go
+++ b/protocol/dataunit/client_server_test.go
@@ -18,12 +18,12 @@ import (
 //
 // It does this by passing an instance of a `Server` to `echoServer()`, which
 // runs in a goroutine. The echo server runs forever or until the passed in
-// context is cancelled. Inside the echo server it checks for
-// `testing.T.Failed()` and stops if there is a test failure. Otherwise, it
-// handles 10 requests at a time, spinning up each request in a new goroutine.
-// Each goroutine handles a response to the client request. Each request is
-// sending a unique 'data unit' to be processed and the response is sent back to
-// the `serverConn` which .
+// context is cancelled. Inside the echo server it checks for any context
+// cancellations and returns early if so (it will optionally record the error if
+// the error is not an expected type). Otherwise, it handles 10 requests at a
+// time, spinning up each request in a new goroutine. Each goroutine handles a
+// response to the client request. Each request is sending a unique 'data unit'
+// to be processed and the response is sent back to the `serverConn`.
 //
 // We use a `net.Pipe()` to simulate the client/server request/response flows.
 // i.e. a write to `clientConn` is readable via `serverConn` (and vice-versa).

--- a/protocol/dataunit/client_server_test.go
+++ b/protocol/dataunit/client_server_test.go
@@ -18,7 +18,7 @@ import (
 //
 // It does this by passing an instance of a `Server` to `echoServer()`, which
 // runs in a goroutine. The echo server runs forever or until the passed in
-// context is cancelled. Inside the echo server it checks for any context
+// context is canceled. Inside the echo server it checks for any context
 // cancellations and returns early if so (it will optionally record the error if
 // the error is not an expected type). Otherwise, it handles 10 requests at a
 // time, spinning up each request in a new goroutine. Each goroutine handles a
@@ -99,8 +99,8 @@ func TestClientContextDeadline(t *testing.T) {
 	}
 }
 
-func TestClientContextCancelled(t *testing.T) {
-	wantErr := errCtxCancelled
+func TestClientContextCanceled(t *testing.T) {
+	wantErr := errCtxCanceled
 	ctx, cancel := context.WithCancelCause(context.Background())
 	cancel(wantErr)
 
@@ -121,7 +121,7 @@ func TestClientContextCancelled(t *testing.T) {
 	}
 }
 
-func TestServerContextCancelled(t *testing.T) {
+func TestServerContextCanceled(t *testing.T) {
 	ctx, cancel := context.WithCancelCause(context.Background())
 	defer cancel(errTestDone)
 
@@ -133,7 +133,7 @@ func TestServerContextCancelled(t *testing.T) {
 		_, _ = c.ExchangeDataUnit(ctx, []byte("hello"))
 	}()
 
-	wantErr := errors.New("server context cancelled")
+	wantErr := errors.New("server context canceled")
 	serverCtx, cancel := context.WithCancelCause(context.Background())
 	cancel(wantErr)
 
@@ -185,7 +185,7 @@ func echoServer(ctx context.Context, s *Server, echoServerErr chan<- error) {
 	for {
 		err := context.Cause(ctx)
 		if err != nil {
-			if err == errTestDone || err == errCtxCancelled {
+			if err == errTestDone || err == errCtxCanceled {
 				return
 			}
 			echoServerErr <- err
@@ -224,6 +224,6 @@ func randDuration(max time.Duration) time.Duration {
 }
 
 var (
-	errCtxCancelled = errors.New("context cancelled")
-	errTestDone     = errors.New("test done")
+	errCtxCanceled = errors.New("context canceled")
+	errTestDone    = errors.New("test done")
 )

--- a/protocol/dataunit/client_server_test.go
+++ b/protocol/dataunit/client_server_test.go
@@ -156,7 +156,9 @@ func TestMultipleResponseError(t *testing.T) {
 	c := &Client{Conn: clientConn}
 	s := &Server{Conn: serverConn}
 
-	go c.ExchangeDataUnit(ctx, []byte("hello"))
+	go func() {
+		_, _ = c.ExchangeDataUnit(ctx, []byte("hello"))
+	}()
 
 	req, r, err := s.ServeDataUnit(ctx)
 	if err != nil {

--- a/protocol/dataunit/client_server_test.go
+++ b/protocol/dataunit/client_server_test.go
@@ -53,6 +53,7 @@ func TestEchoClientAndServer(t *testing.T) {
 				t.Errorf("ExchangeDataUnit(): got %s, expected %s", string(res), string(data))
 				mu.Unlock()
 			}
+			t.Logf("data received from server connection: %s\n", res)
 			<-sem
 		}()
 	}

--- a/protocol/dataunit/client_server_test.go
+++ b/protocol/dataunit/client_server_test.go
@@ -34,7 +34,7 @@ func TestEchoClientAndServer(t *testing.T) {
 		if failed {
 			break
 		}
-		req := []byte(strconv.FormatInt(int64(i), 10))
+		data := []byte(strconv.FormatInt(int64(i), 10))
 		sem <- struct{}{}
 		wg.Add(1)
 		go func() {
@@ -42,15 +42,15 @@ func TestEchoClientAndServer(t *testing.T) {
 			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
 			time.Sleep(randDuration(10 * time.Millisecond))
-			res, err := c.ExchangeDataUnit(ctx, req)
+			res, err := c.ExchangeDataUnit(ctx, data)
 			if err != nil {
 				mu.Lock()
 				t.Errorf("ExchangeDataUnit(): err == %v", err)
 				mu.Unlock()
 			}
-			if !bytes.Equal(req, res) {
+			if !bytes.Equal(data, res) {
 				mu.Lock()
-				t.Errorf("ExchangeDataUnit(): got %s, expected %s", string(res), string(req))
+				t.Errorf("ExchangeDataUnit(): got %s, expected %s", string(res), string(data))
 				mu.Unlock()
 			}
 			<-sem
@@ -174,7 +174,7 @@ func echoServer(t *testing.T, ctx context.Context, s *Server, mu *sync.Mutex) er
 			reqCtx, cancel := context.WithCancel(ctx)
 			defer cancel()
 
-			req, r, err := s.ServeDataUnit(reqCtx)
+			data, r, err := s.ServeDataUnit(reqCtx)
 			if err != nil {
 				if err == errTestDone {
 					return
@@ -184,7 +184,7 @@ func echoServer(t *testing.T, ctx context.Context, s *Server, mu *sync.Mutex) er
 				mu.Unlock()
 			}
 			time.Sleep(randDuration(10 * time.Millisecond))
-			err = r.RespondDataUnit(reqCtx, req)
+			err = r.RespondDataUnit(reqCtx, data)
 			if err != nil {
 				if err == errTestDone {
 					return

--- a/protocol/dataunit/client_server_test.go
+++ b/protocol/dataunit/client_server_test.go
@@ -191,7 +191,7 @@ func echoServer(t *testing.T, ctx context.Context, s *Server, mu *sync.Mutex) er
 					return
 				}
 				mu.Lock()
-				t.Errorf("echoServer: WriteDataUnit(): err == %v", err)
+				t.Errorf("echoServer: RespondDataUnit(): err == %v", err)
 				mu.Unlock()
 			}
 		}()

--- a/protocol/dataunit/client_server_test.go
+++ b/protocol/dataunit/client_server_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"math/rand"
+	"math/rand/v2"
 	"net"
 	"strconv"
 	"sync"
@@ -219,7 +219,7 @@ func echoServer(ctx context.Context, t *testing.T, s *Server, mu *sync.Mutex) er
 }
 
 func randDuration(max time.Duration) time.Duration {
-	return time.Duration(rand.Int63n(int64(max)))
+	return time.Duration(rand.Int64N(int64(max)))
 }
 
 var (


### PR DESCRIPTION
We're seeing data race issues in CI:
https://github.com/domainr/epp2/actions/runs/8330541688/job/22795438262?pr=22 

There are a few different asynchronous layers within these epp2 tests...

- `echoServer` is run in a goroutine and reads from `t`.
- `echoServer` also runs a separate goroutine that writes to `t`.
- The _caller_ of `echoServer` also runs multiple goroutines to write to `t`.

The changes in this PR should resolve the data race issue. 

Instead of passing around the `*testing.T` I'm using channels to handle the coordination/synchronization of error messages.